### PR TITLE
[ClickHouse org] Prevent inserting logs with timestamp=epoch

### DIFF
--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -88,8 +88,12 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 				for k := 0; k < rs.Len(); k++ {
 					r := rs.At(k)
 					logAttr := attributesToMap(r.Attributes())
+					insertTimestamp := r.Timestamp()
+					if insertTimestamp == 0 {
+						insertTimestamp = r.ObservedTimestamp()
+					}
 					_, err = statement.ExecContext(ctx,
-						r.Timestamp().AsTime(),
+						insertTimestamp.AsTime(),
 						traceutil.TraceIDToHexOrEmptyString(r.TraceID()),
 						traceutil.SpanIDToHexOrEmptyString(r.SpanID()),
 						uint32(r.Flags()),


### PR DESCRIPTION
When the pipeline fails to parse a timestamp, just use the observed timestamp rather than 1970

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>